### PR TITLE
feat: Comment out unused mode options in UserACController

### DIFF
--- a/frontend/src/components/equipment-controllers/UserACController.jsx
+++ b/frontend/src/components/equipment-controllers/UserACController.jsx
@@ -11,8 +11,8 @@ const MODE_OPTIONS = [
   { mode: 'No Mode', icon: <Minus size={20} /> },
   { mode: 'Cool', icon: <Snowflake size={20} /> },
   { mode: 'Heat', icon: <Flame size={20} /> },
-  { mode: 'Fan', icon: <Fan size={20} /> },
-  { mode: 'Dry', icon: <Droplets size={20} /> },
+  // { mode: 'Fan', icon: <Fan size={20} /> },
+  // { mode: 'Dry', icon: <Droplets size={20} /> },
 ];
 
 const FAN_SPEED_OPTIONS = [


### PR DESCRIPTION
This pull request makes a minor change to the `UserACController.jsx` component by commenting out the "Fan" and "Dry" mode options in the `MODE_OPTIONS` array. This means these modes will no longer be available for selection in the UI.

- Commented out the "Fan" and "Dry" modes from the `MODE_OPTIONS` array in `UserACController.jsx`, removing them from the available AC modes in the UI.