### PR TITLE
feat: Update mode options in UserACController to include Swing and Fi…

### DIFF
--- a/frontend/src/components/equipment-controllers/UserACController.jsx
+++ b/frontend/src/components/equipment-controllers/UserACController.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import axios from 'axios';
-import { Minus, Snowflake, Flame, Fan, Droplets, Wind, Power, ChevronLeft, ChevronRight } from 'lucide-react';
+import { Minus, Snowflake, Flame, Fan, RotateCw, Wind, Power, ChevronLeft, ChevronRight } from 'lucide-react';
 
 const MIN_TEMP = 16;
 const MAX_TEMP = 26;
@@ -8,9 +8,9 @@ const ANGLE_RANGE = 270;
 const ANGLE_OFFSET = -135;
 
 const MODE_OPTIONS = [
-  { mode: 'No Mode', icon: <Minus size={20} /> },
-  { mode: 'Cool', icon: <Snowflake size={20} /> },
-  { mode: 'Heat', icon: <Flame size={20} /> },
+  //{ mode: 'No Mode', icon: <Minus size={20} /> },
+  { mode: 'Swing', icon: <RotateCw size={20} /> },
+  { mode: 'Fix', icon: <Fan size={20} /> },
   // { mode: 'Fan', icon: <Fan size={20} /> },
   // { mode: 'Dry', icon: <Droplets size={20} /> },
 ];


### PR DESCRIPTION
This pull request updates the mode options and icons in the `UserACController` component to better reflect available air conditioner modes. The main changes are the replacement of previous modes with new ones and the update of corresponding icons.

**Updates to AC mode options and icons:**

* Removed the "No Mode", "Cool", and "Heat" options and their icons from the `MODE_OPTIONS` array.
* Added new "Swing" and "Fix" modes with corresponding `RotateCw` and `Fan` icons in the `MODE_OPTIONS` array.
* Updated the icon imports to include `RotateCw` instead of `Droplets`.…x modes